### PR TITLE
The default value for the `all` method

### DIFF
--- a/src/Select.php
+++ b/src/Select.php
@@ -19,8 +19,12 @@ class Select
     $this->builder = $builder;
   }
 
-  public function all($table)
+  public function all($table = null)
   {
+    if($table == null){
+      $table = $this->TABLE;
+    }
+    
     $this->stringArray[] = "`$table`.*";
     return $this;
   }


### PR DESCRIPTION
If the all method is set, it includes all the fields of the main table by default