### PR TITLE
Fix #34: whereBetween methods now throw exceptions for invalid input

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -311,9 +311,9 @@ class Builder
 
   public function whereBetween($name, array $values)
   {
-    // Skip adding WHERE clause if array has fewer than 2 elements
-    if (count($values) < 2) {
-      return $this;
+    // Validate that the array contains exactly two elements
+    if (count($values) !== 2) {
+      throw new \Exception("Between values must contain exactly two elements.");
     }
     
     $this->addOperator('AND');
@@ -323,9 +323,9 @@ class Builder
 
   public function orWhereBetween($name, array $values)
   {
-    // Skip adding WHERE clause if array has fewer than 2 elements
-    if (count($values) < 2) {
-      return $this;
+    // Validate that the array contains exactly two elements
+    if (count($values) !== 2) {
+      throw new \Exception("Between values must contain exactly two elements.");
     }
     
     $this->addOperator('OR');
@@ -335,9 +335,9 @@ class Builder
 
   public function whereNotBetween($name, array $values)
   {
-    // Skip adding WHERE clause if array has fewer than 2 elements
-    if (count($values) < 2) {
-      return $this;
+    // Validate that the array contains exactly two elements
+    if (count($values) !== 2) {
+      throw new \Exception("Between values must contain exactly two elements.");
     }
     
     $this->addOperator('AND');
@@ -347,9 +347,9 @@ class Builder
 
   public function orWhereNotBetween($name, array $values)
   {
-    // Skip adding WHERE clause if array has fewer than 2 elements
-    if (count($values) < 2) {
-      return $this;
+    // Validate that the array contains exactly two elements
+    if (count($values) !== 2) {
+      throw new \Exception("Between values must contain exactly two elements.");
     }
     
     $this->addOperator('OR');

--- a/tests/SelectTest.php
+++ b/tests/SelectTest.php
@@ -75,21 +75,59 @@ class SelectTest extends TestCase
 
    public function testWhereBetweenWithInsufficientArrays()
    {
-      // Test whereBetween with empty array - should return all users (no WHERE constraint applied)
-      $users = DB::table('users')->whereBetween('id', [])->get();
-      $this->assertSame(7, count($users)); // Should return all users since no WHERE clause added
+      // Test whereBetween with empty array - should throw exception
+      $this->expectException(\Exception::class);
+      $this->expectExceptionMessage("Between values must contain exactly two elements.");
+      DB::table('users')->whereBetween('id', [])->get();
 
-      // Test whereBetween with single element array - should return all users (no WHERE constraint applied)
-      $users = DB::table('users')->whereBetween('id', [1])->get();
-      $this->assertSame(7, count($users)); // Should return all users since no WHERE clause added
+      // Test whereBetween with single element array - should throw exception
+      $this->expectException(\Exception::class);
+      $this->expectExceptionMessage("Between values must contain exactly two elements.");
+      DB::table('users')->whereBetween('id', [1])->get();
 
-      // Test whereNotBetween with empty array - should return all users (no WHERE constraint applied)
-      $users = DB::table('users')->whereNotBetween('id', [])->get();
-      $this->assertSame(7, count($users)); // Should return all users since no WHERE clause added
+      // Test whereNotBetween with empty array - should throw exception
+      $this->expectException(\Exception::class);
+      $this->expectExceptionMessage("Between values must contain exactly two elements.");
+      DB::table('users')->whereNotBetween('id', [])->get();
 
-      // Test orWhereBetween with insufficient array - should return all users (no WHERE constraint applied)
-      $users = DB::table('users')->where('id', '>', 0)->orWhereBetween('id', [1])->get();
-      $this->assertSame(7, count($users)); // Should return all users since no WHERE clause added
+      // Test orWhereBetween with insufficient array - should throw exception
+      $this->expectException(\Exception::class);
+      $this->expectExceptionMessage("Between values must contain exactly two elements.");
+      DB::table('users')->where('id', '>', 0)->orWhereBetween('id', [1])->get();
+   }
+
+
+   public function testWhereBetweenExceptionScenarios()
+   {
+      // Test whereBetween with empty array
+      $this->expectException(\Exception::class);
+      $this->expectExceptionMessage("Between values must contain exactly two elements.");
+      DB::table('users')->whereBetween('id', []);
+
+      // Test whereBetween with single element array
+      $this->expectException(\Exception::class);
+      $this->expectExceptionMessage("Between values must contain exactly two elements.");
+      DB::table('users')->whereBetween('id', [1]);
+
+      // Test whereBetween with more than two elements
+      $this->expectException(\Exception::class);
+      $this->expectExceptionMessage("Between values must contain exactly two elements.");
+      DB::table('users')->whereBetween('id', [1, 2, 3]);
+
+      // Test orWhereBetween with empty array
+      $this->expectException(\Exception::class);
+      $this->expectExceptionMessage("Between values must contain exactly two elements.");
+      DB::table('users')->orWhereBetween('id', []);
+
+      // Test whereNotBetween with single element array
+      $this->expectException(\Exception::class);
+      $this->expectExceptionMessage("Between values must contain exactly two elements.");
+      DB::table('users')->whereNotBetween('id', [5]);
+
+      // Test orWhereNotBetween with more than two elements
+      $this->expectException(\Exception::class);
+      $this->expectExceptionMessage("Between values must contain exactly two elements.");
+      DB::table('users')->orWhereNotBetween('id', [1, 2, 3, 4]);
    }
 
 


### PR DESCRIPTION
- Add validation to require exactly 2 elements in whereBetween arrays
- Throw Exception with message 'Between values must contain exactly two elements.'
- Update all whereBetween variants: whereBetween, orWhereBetween, whereNotBetween, orWhereNotBetween
- Update existing tests to expect exceptions instead of silent failures
- Add comprehensive test coverage for various invalid input scenarios