### PR TITLE
fix(ci): resolve PHP 8.1 and PostgreSQL compatibility issues

### DIFF
--- a/src/Connection/Connection.php
+++ b/src/Connection/Connection.php
@@ -575,7 +575,7 @@ class Connection implements ConnectionInterface
      *
      * @throws QueryException
      */
-    protected function handleException(PDOException $e, string $sql, array $bindings): false
+    protected function handleException(PDOException $e, string $sql, array $bindings): bool
     {
         if ($this->throwExceptions) {
             throw new QueryException(

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -102,6 +102,31 @@ abstract class IntegrationTestCase extends TestCase
     }
 
     /**
+     * Returns a boolean default value appropriate for the active driver.
+     * PostgreSQL requires TRUE/FALSE for BOOLEAN columns, not 1/0.
+     */
+    protected static function boolDefault(bool $value): string
+    {
+        $driver = strtolower((string) (getenv('DB_DRIVER') ?: 'sqlite'));
+        if ($driver === 'pgsql') {
+            return $value ? 'TRUE' : 'FALSE';
+        }
+        return $value ? '1' : '0';
+    }
+
+    /**
+     * Returns a datetime column type appropriate for the active driver.
+     * PostgreSQL uses TIMESTAMP, MySQL/SQLite use DATETIME.
+     */
+    protected static function datetimeType(): string
+    {
+        return match (strtolower((string) (getenv('DB_DRIVER') ?: 'sqlite'))) {
+            'pgsql'  => 'TIMESTAMP',
+            default  => 'DATETIME',
+        };
+    }
+
+    /**
      * Quote an identifier for the active driver.
      */
     protected static function q(string $identifier): string

--- a/tests/Integration/ModelCrudTest.php
+++ b/tests/Integration/ModelCrudTest.php
@@ -23,6 +23,8 @@ class ModelCrudTest extends IntegrationTestCase
     {
         $ai   = static::autoIncrement();
         $bool = static::boolType();
+        $dt   = static::datetimeType();
+        $boolDefault = static::boolDefault(true);
 
         DB::statement("DROP TABLE IF EXISTS " . static::q('users'));
         DB::statement("
@@ -31,11 +33,11 @@ class ModelCrudTest extends IntegrationTestCase
                 " . static::q('name')       . " VARCHAR(255) NOT NULL,
                 " . static::q('email')      . " VARCHAR(255) NOT NULL,
                 " . static::q('age')        . " INTEGER DEFAULT 0,
-                " . static::q('is_active')  . " {$bool} DEFAULT 1,
+                " . static::q('is_active')  . " {$bool} DEFAULT {$boolDefault},
                 " . static::q('score')      . " DOUBLE PRECISION DEFAULT 0,
                 " . static::q('settings')   . " TEXT DEFAULT NULL,
-                " . static::q('created_at') . " DATETIME DEFAULT NULL,
-                " . static::q('updated_at') . " DATETIME DEFAULT NULL
+                " . static::q('created_at') . " {$dt} DEFAULT NULL,
+                " . static::q('updated_at') . " {$dt} DEFAULT NULL
             )
         ");
     }

--- a/tests/Integration/QueryTest.php
+++ b/tests/Integration/QueryTest.php
@@ -17,8 +17,9 @@ class QueryTest extends IntegrationTestCase
 
     protected static function createSchema(): void
     {
-        $ai   = static::autoIncrement();
-        $bool = static::boolType();
+        $ai          = static::autoIncrement();
+        $bool        = static::boolType();
+        $boolDefault = static::boolDefault(true);
 
         DB::statement("DROP TABLE IF EXISTS " . static::q('orders'));
         DB::statement("DROP TABLE IF EXISTS " . static::q('query_users'));
@@ -29,7 +30,7 @@ class QueryTest extends IntegrationTestCase
                 " . static::q('name')       . " VARCHAR(255),
                 " . static::q('email')      . " VARCHAR(255),
                 " . static::q('age')        . " INTEGER DEFAULT 0,
-                " . static::q('active')     . " {$bool} DEFAULT 1,
+                " . static::q('active')     . " {$bool} DEFAULT {$boolDefault},
                 " . static::q('score')      . " DOUBLE PRECISION DEFAULT 0,
                 " . static::q('role')       . " VARCHAR(50) DEFAULT 'user'
             )

--- a/tests/Integration/SoftDeleteTest.php
+++ b/tests/Integration/SoftDeleteTest.php
@@ -20,13 +20,14 @@ class SoftDeleteTest extends IntegrationTestCase
     protected static function createSchema(): void
     {
         $ai = static::autoIncrement();
+        $dt = static::datetimeType();
 
         DB::statement("DROP TABLE IF EXISTS " . static::q('soft_posts'));
         DB::statement("
             CREATE TABLE " . static::q('soft_posts') . " (
                 " . static::q('id')         . " {$ai},
                 " . static::q('title')      . " VARCHAR(255),
-                " . static::q('deleted_at') . " DATETIME DEFAULT NULL
+                " . static::q('deleted_at') . " {$dt} DEFAULT NULL
             )
         ");
     }


### PR DESCRIPTION
- Connection::handleException(): false → bool (false as standalone return type requires PHP 8.2+; union type false|X still works on 8.1)

- IntegrationTestCase: add datetimeType() helper (TIMESTAMP for pgsql, DATETIME for mysql/sqlite) and boolDefault(bool) helper (TRUE/FALSE for pgsql, 1/0 for others)

- ModelCrudTest, QueryTest, SoftDeleteTest: replace hardcoded DATETIME and DEFAULT 1 with the new cross-driver helpers

Fixes #47