### PR TITLE
fix(pgsql): embed RawExpression in UPDATE without placeholder

### DIFF
--- a/src/Query/Grammars/PostgresGrammar.php
+++ b/src/Query/Grammars/PostgresGrammar.php
@@ -43,12 +43,20 @@ class PostgresGrammar extends Grammar
      */
     public function compileUpdate(string $table, array $state, array $values): string
     {
-        $table = $this->wrapTable($table);
-        $set   = implode(', ', array_map(
-            fn(string $col) => $this->wrapColumn($col) . ' = ?',
-            array_keys($values),
-        ));
+        $table    = $this->wrapTable($table);
+        $setParts = [];
 
+        foreach ($values as $col => $val) {
+            $wrapped = $this->wrapColumn((string) $col);
+            // RawExpression (e.g. increment/decrement) — embed directly, no placeholder.
+            if ($val instanceof \Foxdb\Query\RawExpression) {
+                $setParts[] = "{$wrapped} = {$val->value}";
+            } else {
+                $setParts[] = "{$wrapped} = ?";
+            }
+        }
+
+        $set = implode(', ', $setParts);
         $sql = "UPDATE {$table} SET {$set}";
 
         $where = $this->compileWheres($state);

--- a/tests/Unit/GrammarTest.php
+++ b/tests/Unit/GrammarTest.php
@@ -325,6 +325,41 @@ class GrammarTest extends TestCase
         $this->assertStringNotContainsString('ORDER BY', $sql);
     }
 
+    /**
+     * Regression: PostgresGrammar::compileUpdate() was using array_map on
+     * array_keys() which always produced "col = ?" — even for RawExpression
+     * values (used by increment/decrement). This caused a binding count
+     * mismatch: PostgreSQL received a ? placeholder with no bound value.
+     */
+    public function test_pgsql_update_embeds_raw_expression_without_placeholder(): void
+    {
+        $raw = new \Foxdb\Query\RawExpression('"score" + 10');
+        $sql = $this->pgsql->compileUpdate(
+            'users',
+            $this->state(['wheres' => [$this->where('id')]]),
+            ['score' => $raw],
+        );
+
+        // RawExpression must be embedded directly — no ? placeholder for it.
+        $this->assertSame(
+            'UPDATE "users" SET "score" = "score" + 10 WHERE "id" = ?',
+            $this->norm($sql),
+        );
+    }
+
+    public function test_pgsql_update_mixes_raw_and_normal_values(): void
+    {
+        $raw = new \Foxdb\Query\RawExpression('"score" + 5');
+        $sql = $this->pgsql->compileUpdate(
+            'users',
+            $this->state(['wheres' => [$this->where('id')]]),
+            ['score' => $raw, 'name' => 'Ali'],
+        );
+
+        $this->assertStringContainsString('"score" = "score" + 5', $sql);
+        $this->assertStringContainsString('"name" = ?', $sql);
+    }
+
     // -----------------------------------------------------------------------
     // PostgreSQL — RETURNING
     // -----------------------------------------------------------------------


### PR DESCRIPTION
PostgresGrammar::compileUpdate() was mapping over array_keys() and always emitting `col = ?`, ignoring RawExpression values used by increment() and decrement(). This caused a binding count mismatch on PostgreSQL.

Mirror the logic from Grammar::compileUpdate(): iterate over values, embed RawExpression directly, emit ? only for scalar values.

Adds two regression tests in GrammarTest:
- test_pgsql_update_embeds_raw_expression_without_placeholder
- test_pgsql_update_mixes_raw_and_normal_values

Fixes #49